### PR TITLE
Resize style crop

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "node": "*"
   },
   "dependencies": {
-    "nan": "~1.7.0",
+    "nan": "^1.8.4",
     "readable-stream": "*"
   },
   "devDependencies": {

--- a/src/imagemagick.cc
+++ b/src/imagemagick.cc
@@ -382,7 +382,7 @@ void DoConvert(uv_work_t* req) {
             unsigned int yoffset = context->yoffset;
 
             if ( ! xoffset ) { xoffset = 0; }
-            if ( ! yoffset ) { ypffset = 0; }
+            if ( ! yoffset ) { yoffset = 0; }
 
             // limit canvas size to cropGeometry
             if (debug) printf( "crop to: %d, %d, %d, %d\n", width, height, xoffset, yoffset );

--- a/src/imagemagick.cc
+++ b/src/imagemagick.cc
@@ -528,6 +528,8 @@ NAN_METHOD(Convert) {
     context->debug = obj->Get( NanNew<String>("debug") )->Uint32Value();
     context->ignoreWarnings = obj->Get( NanNew<String>("ignoreWarnings") )->Uint32Value();
     context->maxMemory = obj->Get( NanNew<String>("maxMemory") )->Uint32Value();
+    context->xoffset = obj->Get( NanNew<String>("xoffset") )->Uint32Value();
+    context->yoffset = obj->Get( NanNew<String>("yoffset") )->Uint32Value();
     context->width = obj->Get( NanNew<String>("width") )->Uint32Value();
     context->height = obj->Get( NanNew<String>("height") )->Uint32Value();
     context->quality = obj->Get( NanNew<String>("quality") )->Uint32Value();

--- a/src/imagemagick.cc
+++ b/src/imagemagick.cc
@@ -486,7 +486,9 @@ void GeneratedBlobAfter(uv_work_t* req) {
 //                  trimFuzz:    optional. [0-1) float, default 0. trimmed color distance to edge color, 0 is exact.
 //                  width:       optional. px.
 //                  height:      optional. px.
-//                  resizeStyle: optional. default: "aspectfill". can be "aspectfit", "fill"
+//                  xoffset:     optional. px.
+//                  yoffset:     optional. px.
+//                  resizeStyle: optional. default: "aspectfill". can be "aspectfit", "fill", "crop"
 //                  gravity:     optional. default: "Center". used when resizeStyle is "aspectfill"
 //                                         can be "NorthWest", "North", "NorthEast", "West",
 //                                         "Center", "East", "SouthWest", "South", "SouthEast", "None"

--- a/src/imagemagick.cc
+++ b/src/imagemagick.cc
@@ -265,7 +265,7 @@ void DoConvert(uv_work_t* req) {
             // keep aspect ratio, get the exact provided size, crop top/bottom or left/right if necessary
             double aspectratioExpected = (double)height / (double)width;
             double aspectratioOriginal = (double)image.rows() / (double)image.columns();
-            unsigned int xoffset = 0
+            unsigned int xoffset = 0;
             unsigned int yoffset = 0;
             unsigned int resizewidth;
             unsigned int resizeheight;


### PR DESCRIPTION
Reasoning behind this is that we, sometimes need to crop image, changing its aspect ration, but doing no resize. Gravity doesn't make sense here, because we need to control offsets and width/height ourselves.

PR adds new resizeStyle `crop` and `xoffset` and `yoffset` attributes to accomplish that
