### PR TITLE
Crop option for convert method

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,8 @@ The `options` argument can have following values:
         srcData:        required. Buffer with binary image data
         srcFormat:      optional. force source format if not detected (e.g. 'ICO'), one of http://www.imagemagick.org/script/formats.php
         quality:        optional. 1-100 integer, default 75. JPEG/MIFF/PNG compression level.
-        crop:           optional. Format: "WIDTHxHEIGHT+offsetX+offsetY". Offsets are optional. Crops area of the image using specified geometry. Is applied before trim, resize and filters.
+        crop:           optional. Format: "WIDTHxHEIGHT+offsetX+offsetY". Offsets are optional.
+                        Crops area of the image using specified geometry. Applied before trim, resize and filters.
         trim:           optional. default: false. trims edges that are the background color.
         trimFuzz:       optional. [0-1) float, default 0. trimmed color distance to edge color, 0 is exact.
         width:          optional. px.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The `options` argument can have following values:
         srcData:        required. Buffer with binary image data
         srcFormat:      optional. force source format if not detected (e.g. 'ICO'), one of http://www.imagemagick.org/script/formats.php
         quality:        optional. 1-100 integer, default 75. JPEG/MIFF/PNG compression level.
+        crop:           optional. Format: "WIDTHxHEIGHT+offsetX+offsetY". Offsets are optional. Crops area of the image using specified geometry. Is applied before trim, resize and filters.
         trim:           optional. default: false. trims edges that are the background color.
         trimFuzz:       optional. [0-1) float, default 0. trimmed color distance to edge color, 0 is exact.
         width:          optional. px.

--- a/src/imagemagick.cc
+++ b/src/imagemagick.cc
@@ -79,6 +79,7 @@ struct convert_im_ctx : im_ctx_base {
 
     unsigned int width;
     unsigned int height;
+    std::string crop;
     bool strip;
     bool trim;
     double trimFuzz;
@@ -182,6 +183,10 @@ void DoConvert(uv_work_t* req) {
 
     unsigned int height = context->height;
     if (debug) printf( "height: %d\n", height );
+
+    if ( context->crop.length() > 0 ) {
+      image.crop(Magick::Geometry(context->crop));
+    }
 
     if ( context->strip ) {
         if (debug) printf( "strip: true\n" );
@@ -507,6 +512,9 @@ NAN_METHOD(Convert) {
     context->rotate = obj->Get( NanNew<String>("rotate") )->Int32Value();
     context->flip = obj->Get( NanNew<String>("flip") )->Uint32Value();
     context->density = obj->Get( NanNew<String>("density") )->Int32Value();
+
+    Local<Value> cropValue = obj->Get( NanNew<String>("crop") );
+    context->crop = !cropValue->IsUndefined() ? *NanAsciiString(cropValue) : "";
 
     Local<Value> trimValue = obj->Get( NanNew<String>("trim") );
     if ( (context->trim = ! trimValue->IsUndefined() && trimValue->BooleanValue()) ) {
@@ -1047,3 +1055,4 @@ void init(Handle<Object> exports) {
 // There is no semi-colon after NODE_MODULE as it's not a function (see node.h).
 // see http://nodejs.org/api/addons.html
 NODE_MODULE(imagemagick, init)
+

--- a/test/test.trim.js
+++ b/test/test.trim.js
@@ -95,3 +95,18 @@ test( 'trim half color fuzz resize', function (t) {
     t.end();
 });
 
+test( 'crop', function (t) {
+    var buffer = imagemagick.convert({
+        srcData: require('fs').readFileSync( "test.trim.jpg" ), // 87x106
+        format: 'PNG',
+        crop: '50x50+10+10',
+        debug: debug
+    });
+    t.equal( Buffer.isBuffer(buffer), true, 'buffer is Buffer' );
+    var info = imagemagick.identify({srcData: buffer });
+    t.equal( info.width, 50 );
+    t.equal( info.height, 50 );
+    saveToFileIfDebug( buffer, "out.trim-half-resize.png" );
+    t.end();
+});
+


### PR DESCRIPTION
Implemented using Magick's Geometry(std::string) constructor which takes string "WIDTHxHEIGHT[+offsetX[+offsetY]]". Also added basic test case. 
No check for format validity other than what Magick does.
