### PR TITLE
Drop support for node.js 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ node_js:
   - "0.12"
   - "0.11"
   - "0.10"
-  - "0.8"
 addons:
   apt:
     packages:

--- a/index.js
+++ b/index.js
@@ -5,10 +5,6 @@ module.exports = require(__dirname + '/build/Release/imagemagick.node');
 var stream = require('stream');
 var util = require('util');
 
-// node v0.10+ use native Transform, else polyfill
-var Transform = stream.Transform ||
-  require('readable-stream').Transform;
-
 function Convert(options) {
   // allow use without new
   if (!(this instanceof Convert)) {
@@ -19,9 +15,9 @@ function Convert(options) {
   this._bufs = [];
 
   // init Transform
-  Transform.call(this, options);
+  stream.Transform.call(this, options);
 }
-util.inherits(Convert, Transform);
+util.inherits(Convert, stream.Transform);
 
 Convert.prototype._transform = function (chunk, enc, done) {
   this._bufs.push(chunk);

--- a/package.json
+++ b/package.json
@@ -21,11 +21,10 @@
     "install": "node-gyp rebuild"
   },
   "engines": {
-    "node": "*"
+    "node": ">=0.10.0"
   },
   "dependencies": {
-    "nan": "~1.7.0",
-    "readable-stream": "*"
+    "nan": "~1.7.0"
   },
   "devDependencies": {
     "tap": "*",

--- a/src/imagemagick.cc
+++ b/src/imagemagick.cc
@@ -1025,7 +1025,6 @@ NAN_METHOD(GetQuantumDepth) {
 }
 
 void init(Handle<Object> exports) {
-#if NODE_MODULE_VERSION >= 14
     NODE_SET_METHOD(exports, "convert", Convert);
     NODE_SET_METHOD(exports, "identify", Identify);
     NODE_SET_METHOD(exports, "quantizeColors", QuantizeColors);
@@ -1033,15 +1032,6 @@ void init(Handle<Object> exports) {
     NODE_SET_METHOD(exports, "version", Version);
     NODE_SET_METHOD(exports, "getConstPixels", GetConstPixels);
     NODE_SET_METHOD(exports, "quantumDepth", GetQuantumDepth); // QuantumDepth is already defined
-#else
-    exports->Set(NanNew<String>("convert"), FunctionTemplate::New(Convert)->GetFunction());
-    exports->Set(NanNew<String>("identify"), FunctionTemplate::New(Identify)->GetFunction());
-    exports->Set(NanNew<String>("quantizeColors"), FunctionTemplate::New(QuantizeColors)->GetFunction());
-    exports->Set(NanNew<String>("composite"), FunctionTemplate::New(Composite)->GetFunction());
-    exports->Set(NanNew<String>("version"), FunctionTemplate::New(Version)->GetFunction());
-    exports->Set(NanNew<String>("getConstPixels"), FunctionTemplate::New(GetConstPixels)->GetFunction());
-    exports->Set(NanNew<String>("quantumDepth"), FunctionTemplate::New(GetQuantumDepth)->GetFunction());
-#endif
 }
 
 // There is no semi-colon after NODE_MODULE as it's not a function (see node.h).


### PR DESCRIPTION
Please take a look whether I missed some place. I don't think so, though.

The [check for `NODE_MODULE_VERSION >= 14`](https://github.com/elad/node-imagemagick-native/blob/remove-0.8-support/src/imagemagick.cc#L1028) seems to be required for node 0.10 as well.