### PR TITLE
Update travis nodejs v4.0 to v4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "4.0"
+  - "4.2"
   - "0.12"
   - "0.11"
   - "0.10"


### PR DESCRIPTION
It would be better to travis with nodejs 4.2, because it is Long-term Support version as https://github.com/nodejs/LTS.