### PR TITLE
Fix build on Windows (Visual Studio 2015)

### DIFF
--- a/src/imagemagick.cc
+++ b/src/imagemagick.cc
@@ -2,7 +2,7 @@
 #define BUILDING_NODE_EXTENSION
 #endif  // BUILDING_NODE_EXTENSION
 
-#if _MSC_VER
+#if _MSC_VER && _MSC_VER < 1900
 #define snprintf _snprintf
 #endif
 


### PR DESCRIPTION
This solves #110.

It's similar to this issue on node-canvas: https://github.com/Automattic/node-canvas/issues/605

Basically, Visual Studio didn't have snprintf, so it had to be polyfilled, like it has been done here. But now, in 2015, snprintf was finally implemented, which leads to it being defined twice.
This change lets me compile the project on Windows 7 x64, with Visual Studio 2015.