### PR TITLE
Fix: enable exception handling.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -22,8 +22,8 @@
     {
       "target_name": "imagemagick",
       "sources": [ "src/imagemagick.cc" ],
-      'cflags!': [ '-fno-exceptions' ],
-      'cflags_cc!': [ '-fno-exceptions' ],
+      'cflags!': [ '-fno-exceptions','-fno-rtti' ],
+      'cflags_cc!': [ '-fno-exceptions','-fno-rtti' ],
       "include_dirs" : [
         "<!(node -e \"require('nan')\")"
       ],
@@ -46,6 +46,7 @@
         ['OSX_VER == "10.9" or OSX_VER == "10.10" or OSX_VER == "10.11"', {
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'GCC_ENABLE_CPP_RTTI': 'YES',
             'OTHER_CFLAGS': [
               '<!@(Magick++-config --cflags)'
             ],
@@ -67,6 +68,7 @@
         ['OS=="mac"', {
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+            'GCC_ENABLE_CPP_RTTI': 'YES',
             'OTHER_CFLAGS': [
               '<!@(Magick++-config --cflags)'
             ]


### PR DESCRIPTION
since this addon contains no throw statement,compiler(MacOS/llvm) will not trigger
generation of RTTI which needed for type match in try-catch clause.

Reference:
https://developer.apple.com/library/mac/documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-SW10