### PR TITLE
Document the Magick++-config work-around.

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,10 @@ Tested with ImageMagick 6.7.7 on CentOS 6 and Mac OS X Lion, Ubuntu 12.04 .
 
     sudo apt-get install libmagick++-dev
 
-Make sure you can find Magick++-config in your PATH.
+Make sure you can find Magick++-config in your PATH. Packages on some newer distributions, such as Ubuntu 16.04, might be missing a link into `/usr/bin`. If that is the case, do this.
+
+    sudo ln -s `ls /usr/lib/\`uname -p\`-linux-gnu/ImageMagick-*/bin-Q16/Magick++-config | head -n 1` /usr/local/bin/
+
 Then:
 
     npm install imagemagick-native


### PR DESCRIPTION
Per #146, newer Ubuntu distributions might omit a link necessary to make Magick++-config for ImageMagick work correctly. @cartuchogl suggested a work-around, and this patch adds it to the README.