### PR TITLE
Update README.md with docker details in "Installation" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,17 @@ Then:
   ```
   brew install pkgconfig
   ```
+  
+  * Docker: to run `node-gyp` properly is required `build-essential` in Devian distros or `Development Tools` in CentOS
+
+
+      sudo apt-get install build-essential
+
+       	or
+
+      sudo yum groupinstall "Development Tools"
+
+  
 
 <a name='installation-windows'></a>
 


### PR DESCRIPTION
Otherwise node-gyp fails like this:
http://stackoverflow.com/questions/14772508/npm-failed-to-install-time-with-make-not-found-error

It´s posible this build-essential package was required in another scenario.