### PR TITLE
Clear Orientation EXIF on AutoOrient

### DIFF
--- a/src/imagemagick.cc
+++ b/src/imagemagick.cc
@@ -191,6 +191,9 @@ void AutoOrient(Magick::Image *image) {
             image->rotate(270);
             break;
     }
+
+    // Erase orientation metadata after rotating the image to avoid double-rotation
+    image->orientation(Magick::OrientationType::UndefinedOrientation);
 }
 
 void DoConvert(uv_work_t* req) {

--- a/test/test.auto.orient.js
+++ b/test/test.auto.orient.js
@@ -33,7 +33,7 @@ test( 'convert autoOrient option', function (t) {
 
         var buffer = imagemagick.convert({
             srcData: fs.readFileSync( path.join(__dirname, 'orientation-suite', f) ),
-            format: 'PNG',
+            format: 'JPEG',
             autoOrient: true,
             debug: debug
         });


### PR DESCRIPTION
The `test.auto.orientation.js` file was converting the result output from JPEG to PNG, causing EXIF data to be stripped off as PNG's do not support this feature. When using JPEG, the EXIF data remains on the photo, causing it to be double-rotated when viewed on macOS.

This PR clears the `image->orientation()` metadata to be unset after orientation takes place (so that the now-rotated image is not again-rotated by Mac to be still-incorrect). It also fixes the test so that the output image format is the same as the input format (JPEG) for testing this new change (since PNG doesn't honor the EXIF orientation flag).