### PR TITLE
Add support for macOS 10.13

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -43,7 +43,7 @@
             '_SSIZE_T_',
           ]
         }],
-        ['OSX_VER == "10.9" or OSX_VER == "10.10" or OSX_VER == "10.11" or OSX_VER == "10.12"', {
+        ['OSX_VER == "10.9" or OSX_VER == "10.10" or OSX_VER == "10.11" or OSX_VER == "10.12" or OSX_VER == "10.13"', {
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
             'OTHER_CFLAGS': [


### PR DESCRIPTION
When installing on MacOS High Sierra I was getting "Symbol not found" errors, similar to #17.

Updating the `binding.gyp` to include `10.13` and rebuilding fixes these errors.