### PR TITLE
Update ci test to LTS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ dist: trusty
 sudo: false
 language: node_js
 node_js:
+  - "10"
   - "8"
-  - "7"
   - "6"
   - "4"
 env:


### PR DESCRIPTION
- Add Node.js10
- Drop Node.js7
    - Node.js 7 is an EOL